### PR TITLE
missing sasl modules in latest alpine 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Denis Paiva <denispaiva@gmail.com>
 # CREDITS Uri Savelchev <alterrebe@gmail.com>
 
 # Packages: update
-RUN apk -U add postfix ca-certificates libsasl py-pip supervisor rsyslog
+RUN apk -U add postfix ca-certificates libsasl cyrus-sasl-login cyrus-sasl-plainpy-pip supervisor rsyslog
 RUN pip install j2cli
 
 # Add files
@@ -13,6 +13,7 @@ RUN mkfifo /var/spool/postfix/public/pickup \
 
 # Configure: supervisor
 ADD bin/dfg.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/dfg.sh
 ADD conf/supervisor-all.ini /etc/supervisor.d/
 
 # Runner


### PR DESCRIPTION
in the newest alpine build when the packer libsasl is added the login and plain modules are missing these two additional packages are needed to auth , also corrected the permissions to /usr/local/bin/dfg.sh